### PR TITLE
Switch from assert false to get_parent as a temporary fix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,9 +18,9 @@ jobs:
           git ls-files -- \*.cmake \*CMakeLists.txt | xargs cmake-format --check
       - name: Check clang formatting
         run: |
-          if [ -n "${{github.base_ref}}" ]
+          if [ -n "${{github.event.pull_request.base.sha}}" ]
           then
-            if ! git clang-format --quiet --diff "${{github.base_ref}}" HEAD
+            if ! git clang-format-18 --quiet --diff "${{github.event.pull_request.base.sha}}" HEAD
             then
               echo incorrect formatting
               exit 1

--- a/rpc/src/service.cpp
+++ b/rpc/src/service.cpp
@@ -802,9 +802,24 @@ namespace rpc
                             }
                             else
                             {
-                                // untested path
-                                RPC_ASSERT(false);
-                                // caller = get_parent();
+                                // UNTESTED PATH!!!
+                                // It has been worked out that this happens when a reference to an zone is passed to a
+                                // zone that does not know of its existence.
+                                // SOLUTION:
+                                // Create a temporary "snail trail" of service proxies if not present from the caller to
+                                // the called this would result in the i_marshaller::send method having an additional
+                                // list of zones that are referred to in any parameter that is passing an interface.
+                                // This list needs to be not encrypted along the chain of services in a function call so
+                                // that they can maintain that snail trail. All service proxies whether already present
+                                // or ephemeral will need to be protected with a shared pointer for the lifetime of the
+                                // call. This will require a change to the code generator to populate the list of zones
+                                // in the send method for the receiving service to process.
+                                // TEMPORARY FIX:
+                                // This fix below assumes that the bottom most parent knows about the zone in question.
+                                // However one branch may have a zone with a child that the bottom most node does not
+                                // know about so this will break.  With the proposed snail trail fix this logic branch
+                                // should assert false as it should then be impossible to get to this position.
+                                caller = get_parent();
                             }
 
                             RPC_ASSERT(caller);


### PR DESCRIPTION
It has been worked out that this happens when a reference to an zone is passed to a zone that does not know of its existence.
SOLUTION:
Create a temporary "snail trail" of service proxies if not present from the caller to the called this would result in the i_marshaller::send method having an additional list of zones that are referred to in any parameter that is passing an interface. This list needs to be not encrypted along the chain of services in a function call so that they can maintain that snail trail. All service proxies whether already present or ephemeral will need to be protected with a shared pointer for the lifetime of the call. This will require a change to the code generator to populate the list of zones in the send method for the receiving service to process. TEMPORARY FIX:
This fix below assumes that the bottom most parent knows about the zone in question. However one branch may have a zone with a child that the bottom most node does not know about so this will break.  With the proposed snail trail fix this logic branch should assert false as it should then be impossible to get to this position.